### PR TITLE
Delete records for a process on rollback

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -54,6 +54,8 @@ class adminapprove extends libbase {
     }
 
     public function rollback_course($processid, $instanceid, $course) {
+        global $DB;
+        $DB->delete_records('lifecyclestep_adminapprove', array('processid' => $processid));
         return;
     }
 


### PR DESCRIPTION
This is only important when aborting processes.