### PR TITLE
Added status message to view in teachers view

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ before_install:
   - composer selfupdate
   - composer create-project -n --no-dev --prefer-dist blackboard-open-source/moodle-plugin-ci ci ^2
   - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
-  - moodle-plugin-ci add-plugin --branch feature/subplugin-settings justusdieckmann/moodle-tool_lifecycle
+  - moodle-plugin-ci add-plugin learnweb/moodle-tool_lifecycle
 
 jobs:
   include:

--- a/classes/decision_table.php
+++ b/classes/decision_table.php
@@ -50,7 +50,8 @@ class decision_table extends \table_sql {
                         get_string('startdate'),
                         get_string('tools', 'lifecyclestep_adminapprove')));
         $this->column_nosort = array('checkbox', 'tools');
-        $fields = 'm.id, w.displaytitle as workflow, c.id as courseid, c.fullname as course, cc.name as category, c.startdate, m.status';
+        $fields = 'm.id, w.displaytitle as workflow, c.id as courseid, c.fullname as course, cc.name as category,
+            c.startdate, m.status';
         $from = '{lifecyclestep_adminapprove} m ' .
                 'LEFT JOIN {tool_lifecycle_process} p ON p.id = m.processid ' .
                 'LEFT JOIN {course} c ON c.id = p.courseid ' .

--- a/interactionlib.php
+++ b/interactionlib.php
@@ -1,0 +1,103 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Interface for the interactions of the subplugintype step
+ * It has to be implemented by all subplugins that want to use the interaction view.
+ *
+ * @package tool_lifecycle
+ * @subpackage step
+ * @copyright  2017 Tobias Reischmann WWU
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace tool_lifecycle\step;
+
+use lifecyclestep_duplicate\form_duplicate;
+use tool_lifecycle\entity\process;
+use tool_lifecycle\entity\step_subplugin;
+use tool_lifecycle\manager\process_data_manager;
+use tool_lifecycle\manager\process_manager;
+use tool_lifecycle\manager\settings_manager;
+use tool_lifecycle\manager\step_manager;
+use tool_lifecycle\response\step_interactive_response;
+use tool_lifecycle\settings_type;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__ . '/../interactionlib.php');
+require_once(__DIR__ . '/lib.php');
+
+
+class interactionadminapprove extends interactionlibbase {
+
+
+    /**
+     * Returns the capability a user has to have to make decisions for a specific course.
+     * @return string capability string.
+     */
+    public function get_relevant_capability() {
+        return null;
+    }
+
+    /**
+     * Returns an array of interaction tools to be displayed to be displayed on the view.php for the given process
+     * Every entry is itself an array which consist of three elements:
+     *  'action' => an action string, which is later passed to handle_action
+     *  'alt' => a string text of the button
+     * @param process $process process the action tools are requested for
+     * @return array of action tools
+     */
+    public function get_action_tools($process) {
+        return [];
+    }
+
+    /**
+     * Returns the status message for the given process.
+     * @param process $process process the status message is requested for
+     * @return string status message
+     * @throws \coding_exception
+     */
+    public function get_status_message($process) {
+        $step = step_manager::get_step_instance_by_workflow_index($process->workflowid, $process->stepindex);
+        return settings_manager::get_settings($step->id, settings_type::STEP)['statusmessage'];
+    }
+
+    /**
+     * Returns the display name for the given action.
+     * Used for the past actions table in view.php.
+     * @param string $action Identifier of action
+     * @param string $userlink html-link with username as text that refers to the user profile.
+     * @return string action display name
+     */
+    public function get_action_string($action, $userlink) {
+        return "";
+    }
+
+    /**
+     * Called when a user triggered an action for a process instance.
+     * @param process $process instance of the process the action was triggered upon.
+     * @param step_subplugin $step instance of the step the process is currently in.
+     * @param string $action action string. The function is called with 'default', during interactive processing.
+     * @return step_interactive_response defines if the step still wants to process this course
+     *      - proceed: the step has finished and respective controller class can take over.
+     *      - stillprocessing: the step still wants to process the course and is responsible for rendering the site.
+     *      - noaction: the action is not defined for the step.
+     *      - rollback: the step has finished and respective controller class should rollback the process.
+     */
+    public function handle_interaction($process, $step, $action = 'default') {
+        return step_interactive_response::no_action();
+    }
+}

--- a/lang/en/lifecyclestep_adminapprove.php
+++ b/lang/en/lifecyclestep_adminapprove.php
@@ -46,5 +46,4 @@ $string['bulkactions'] = 'Bulk actions';
 $string['proceedall'] = 'Proceed all';
 $string['rollbackall'] = 'Rollback all';
 $string['statusmessage'] = 'Status message';
-$string['statusmessage_help'] = 'Status message, which is displayed to a teacher, 
-if a process of a course is at this admin approve step.';
+$string['statusmessage_help'] = 'Status message, which is displayed to a teacher, if a process of a course is at this admin approve step.';

--- a/lang/en/lifecyclestep_adminapprove.php
+++ b/lang/en/lifecyclestep_adminapprove.php
@@ -45,3 +45,6 @@ $string['nostepstodisplay'] = 'There are currently no steps waiting for interact
 $string['bulkactions'] = 'Bulk actions';
 $string['proceedall'] = 'Proceed all';
 $string['rollbackall'] = 'Rollback all';
+$string['statusmessage'] = 'Status message';
+$string['statusmessage_help'] = 'Status message, which is displayed to a teacher, 
+if a process of a course is at this admin approve step.';

--- a/lib.php
+++ b/lib.php
@@ -93,4 +93,17 @@ class adminapprove extends libbase {
                 get_string('emailcontenthtml', 'lifecyclestep_adminapprove', $obj));
         }
     }
+
+    public function instance_settings() {
+        return array(
+            new instance_setting('statusmessage', PARAM_TEXT),
+        );
+    }
+
+    public function extend_add_instance_form_definition($mform) {
+        $elementname = 'statusmessage';
+        $mform->addElement('text', $elementname, get_string('statusmessage', 'lifecyclestep_adminapprove'));
+        $mform->addHelpButton($elementname, 'statusmessage', 'lifecyclestep_adminapprove');
+        $mform->setType($elementname, PARAM_TEXT);
+    }
 }

--- a/tests/behat/teacherview.feature
+++ b/tests/behat/teacherview.feature
@@ -1,13 +1,16 @@
 @lifecyclestep @lifecyclestep_adminapprove @javascript
-Feature: Add a workflow with an adminapprove step and test it
+Feature: Add a workflow with an adminapprove step and test the status in the teachers view.
 
   Background:
     Given the following "courses" exist:
       | fullname | shortname |
       | Course 1 | C1        |
-      | Course 2 | C2        |
-      | Course 3 | C3        |
-      | Course 4 | C4        |
+    And the following "users" exist:
+      | username | firstname | lastname | email             |
+      | teacher | Terry1    | Teacher1 | teacher1@example.com |
+    And the following "course enrolments" exist:
+      | user     | course | role           |
+      | teacher | C1     | editingteacher |
     And I log in as "admin"
     And I navigate to "Plugins > Life Cycle > Workflow Settings" in site administration
     And I press "Add Workflow"
@@ -26,25 +29,13 @@ Feature: Add a workflow with an adminapprove step and test it
       | Instance Name | Admin Approve Step #1 |
       | Status message | My status |
     And I press "Save changes"
-    And I select "Delete Course Step" from the "stepname" singleselect
-    And I set the field "Instance Name" to "Delete Course #1"
-    And I press "Save changes"
     And I press "Back"
     And I press "Activate"
+    And I run the scheduled task "tool_lifecycle\task\lifecycle_task"
+    And I log out
 
   Scenario: Test interaction of admin approve step
-    When I navigate to "Plugins > Life Cycle > Manage Admin Approve Steps" in site administration
-    Then I should see "There are currently no steps waiting for interaction."
-    When I run the scheduled task "tool_lifecycle\task\lifecycle_task"
-    And I reload the page
-    And I click on "Admin Approve Step #1" "link"
-    Then I should see "Course 1"
-    And I should see "Course 2"
-    And I should see "Course 3"
-    And I should see "Course 4"
-    When I click on the tool "Proceed" in the "Course 1" row of the "lifecyclestep_adminapprove-decisiontable" table
-    And I wait to be redirected
-    Then I should not see "Course 1"
-    When I click on the tool "Rollback" in the "Course 2" row of the "lifecyclestep_adminapprove-decisiontable" table
-    And I wait to be redirected
-    Then I should not see "Course 2"
+    When I log in as "teacher"
+    And I am on lifecycle view
+    Then I should see "Course 1" in the "tool_lifecycle_remaining" "table"
+    And I should see "My status" in the "tool_lifecycle_remaining" "table"


### PR DESCRIPTION
Currently, if a process is at an admin approve step, teachers get no other information on the lifecycle view than "workflow is running". This PR adds an status message as a setting for a admin approve step instance and displays it in the lifecycle view for teachers.