### PR TITLE
Currently no mails are sent to an admin

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -35,7 +35,7 @@ require_once(__DIR__ . '/../lib.php');
 
 class adminapprove extends libbase {
 
-    private $newcourses = 0;
+    private static $newcourses = 0;
 
     /**
      * @param int $processid of the respective process.
@@ -49,7 +49,7 @@ class adminapprove extends libbase {
         $record->processid = $processid;
         $record->status = 0;
         $DB->insert_record('lifecyclestep_adminapprove', $record);
-        $this->newcourses++;
+        self::$newcourses++;
         return step_response::waiting();
     }
 
@@ -79,15 +79,15 @@ class adminapprove extends libbase {
     }
 
     public function pre_processing_bulk_operation() {
-        $this->newcourses = 0;
+        self::$newcourses = 0;
     }
 
     public function post_processing_bulk_operation() {
         global $CFG;
-        if ($this->newcourses > 0) {
+        if (self::$newcourses > 0) {
             $obj = new \stdClass();
-            $obj->amount = $this->newcourses;
-            $obj->link = $CFG->wwwroot . '/admin/tool/lifecycle/step/adminapprove/approvestep.php';
+            $obj->amount = self::$newcourses;
+            $obj->link = $CFG->wwwroot . '/admin/tool/lifecycle/step/adminapprove/index.php';
 
             email_to_user(get_admin(), \core_user::get_noreply_user(),
                 get_string('emailsubject', 'lifecyclestep_adminapprove'),

--- a/tests/admin_approve_test.php
+++ b/tests/admin_approve_test.php
@@ -1,0 +1,70 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__ . '/../../../tests/generator/lib.php');
+
+use tool_lifecycle\manager\process_manager;
+use tool_lifecycle\manager\settings_manager;
+use tool_lifecycle\manager\workflow_manager;
+use tool_lifecycle\processor;
+use tool_lifecycle\task\lifecycle_task;
+
+/**
+ * Tests the admin approve step.
+ *
+ * @package    lifecyclestep_adminapprove
+ * @group      lifecyclestep_adminapprove
+ * @group      lifecyclestep
+ * @category   test
+ * @copyright  2019 Justus Dieckmann
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class lifecyclestep_adminapprove_admin_approve_test_testcase extends \advanced_testcase {
+
+    public function test_admin_mail() {
+        $this->resetAfterTest(true);
+        $generator = $this->getDataGenerator()->get_plugin_generator('tool_lifecycle');
+        $workflow = $generator->create_workflow([], []);
+        $trigger = $generator->create_trigger('manual', 'manual', $workflow->id);
+        $generator->create_step('adminapprove', 'adminapprove', $workflow->id);
+        workflow_manager::activate_workflow($workflow->id);
+
+        // Create 4 courses.
+        $course1 = $this->getDataGenerator()->create_course();
+        $course2 = $this->getDataGenerator()->create_course();
+        $course3 = $this->getDataGenerator()->create_course();
+        $course4 = $this->getDataGenerator()->create_course();
+
+        process_manager::manually_trigger_process($course1->id, $trigger->id);
+        process_manager::manually_trigger_process($course2->id, $trigger->id);
+        process_manager::manually_trigger_process($course3->id, $trigger->id);
+        process_manager::manually_trigger_process($course4->id, $trigger->id);
+
+        // Prevent output from the task execution.
+        $this->setOutputCallback(function() {
+        });
+
+        // Create an email sink to query it after the processing.
+        $sink = $this->redirectEmails();
+        $task = new lifecycle_task();
+        $task->execute();
+        $this->assertCount(1, $sink->get_messages());
+        $sink->close();
+    }
+
+}


### PR DESCRIPTION
The field newcourses is not preserved through multiple step instances. However, during the task executing the methods for the pre_processing, post_processing and the generell processing are called on different instances of the step class. Altering the newcourses variable to a static field solves this issue. I also directly added a phpunit test for this.