### PR TITLE
Added privacy provider for lifecyclestep_adminapprove

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,40 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace lifecyclestep_adminapprove\privacy;
+
+use core_privacy\local\metadata\null_provider;
+
+/**
+ * Privacy subsystem implementation for lifecyclestep_adminapprove.
+ *
+ * @package     lifecyclestep_adminapprove
+ * @copyright   2022 ISB Bayern
+ * @author      Philipp Memmel
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class provider implements null_provider {
+
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return string the reason
+     */
+    public static function get_reason() : string {
+        return 'privacy:metadata';
+    }
+}

--- a/lang/de/lifecyclestep_adminapprove.php
+++ b/lang/de/lifecyclestep_adminapprove.php
@@ -24,6 +24,7 @@
  */
 
 $string['pluginname'] = 'Adminbestätigungs-Schritt';
+$string['privacy:metadata'] = 'Dieses Subplugin speichert keine persönlichen Daten.';
 $string['emailsubject'] = 'Kurs-Lebenszyklus: Es gibt neue Kurse, die auf Bestätigung warten.';
 $string['emailcontent'] = 'Es gibt {$a->amount} neue Kurse, die auf Bestätigung warten. Bitte besuchen Sie {$a->url}.';
 $string['emailcontenthtml'] = 'Es gibt {$a->amount} neue Kurse, die auf Bestätigung warten. Bitte klicken Sie auf <a href="{$a->url}">diesen Link</a>.';

--- a/lang/en/lifecyclestep_adminapprove.php
+++ b/lang/en/lifecyclestep_adminapprove.php
@@ -23,6 +23,7 @@
  */
 
 $string['pluginname'] = 'Admin Approve Step';
+$string['privacy:metadata'] = 'This subplugin does not store any personal data.';
 $string['emailsubject'] = 'Lifecycle: There are new courses waiting for confirmation.';
 $string['emailcontent'] = 'There are {$a->amount} new courses waiting for confirmation. Please visit {$a->url}.';
 $string['emailcontenthtml'] = 'There are {$a->amount} new courses waiting for confirmation. Please visit <a href="{$a->url}">this link</a>.';


### PR DESCRIPTION
Missing privacy provider makes unit tests fail. So here is one. As this plugin does not store any additional user data a null provider should be enough IMO.